### PR TITLE
Fix modname to match published name

### DIFF
--- a/cmd/goimportcycle/main.go
+++ b/cmd/goimportcycle/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"flag"
-	"github.com/samlitowitz/goimportcycleviz/internal"
-	"github.com/samlitowitz/goimportcycleviz/internal/dot"
-	"github.com/samlitowitz/goimportcycleviz/internal/modfile"
 	"io/ioutil"
 	"log"
 	"path/filepath"
+
+	"github.com/samlitowitz/goimportcycle/internal"
+	"github.com/samlitowitz/goimportcycle/internal/dot"
+	"github.com/samlitowitz/goimportcycle/internal/modfile"
 )
 
 func main() {
@@ -49,5 +50,4 @@ func main() {
 
 		ioutil.WriteFile(dotFile, output, 0644)
 	}
-
 }

--- a/examples/importcycle/a/a.go
+++ b/examples/importcycle/a/a.go
@@ -1,8 +1,8 @@
 package a
 
 import (
-	"github.com/samlitowitz/goimportcycleviz/examples/importcycle/b"
-	c "github.com/samlitowitz/goimportcycleviz/examples/importcycle/b"
+	"github.com/samlitowitz/goimportcycle/examples/importcycle/b"
+	c "github.com/samlitowitz/goimportcycle/examples/importcycle/b"
 )
 
 type A struct {

--- a/examples/importcycle/b/types.go
+++ b/examples/importcycle/b/types.go
@@ -1,6 +1,6 @@
 package b
 
-import "github.com/samlitowitz/goimportcycleviz/examples/importcycle/a"
+import "github.com/samlitowitz/goimportcycle/examples/importcycle/a"
 
 type IDer interface {
 	ID() a.ID

--- a/examples/importcycle/main.go
+++ b/examples/importcycle/main.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/samlitowitz/goimportcycleviz/examples/importcycle/a"
+
+	"github.com/samlitowitz/goimportcycle/examples/importcycle/a"
 )
 
 func main() {

--- a/internal/dot/marshal.go
+++ b/internal/dot/marshal.go
@@ -3,9 +3,10 @@ package dot
 import (
 	"bytes"
 	"fmt"
-	"github.com/samlitowitz/goimportcycleviz/internal"
-	"github.com/samlitowitz/goimportcycleviz/internal/ast/pkg"
 	"path/filepath"
+
+	"github.com/samlitowitz/goimportcycle/internal"
+	"github.com/samlitowitz/goimportcycle/internal/ast/pkg"
 )
 
 func Marshal(files []*internal.File) ([]byte, error) {
@@ -81,8 +82,10 @@ func Marshal(files []*internal.File) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-type nodeID string
-type subgraphID string
+type (
+	nodeID     string
+	subgraphID string
+)
 
 type marshaler struct {
 	edges map[nodeID]map[nodeID]struct{}

--- a/internal/file.go
+++ b/internal/file.go
@@ -1,6 +1,6 @@
 package internal
 
-import "github.com/samlitowitz/goimportcycleviz/internal/ast/pkg"
+import "github.com/samlitowitz/goimportcycle/internal/ast/pkg"
 
 type File struct {
 	Name    pkg.FilePath

--- a/internal/import_grapher.go
+++ b/internal/import_grapher.go
@@ -2,7 +2,6 @@ package internal
 
 import (
 	"fmt"
-	"github.com/samlitowitz/goimportcycleviz/internal/ast/pkg"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -11,6 +10,8 @@ import (
 	"log"
 	"path/filepath"
 	"strings"
+
+	"github.com/samlitowitz/goimportcycle/internal/ast/pkg"
 )
 
 type ImportGrapher struct {


### PR DESCRIPTION
The module 'goimportcycleviz' is referenced in the code rather than
using the published name of 'goimportcycle' which causes `go build` to
fail.