### PR TITLE
Fix AST parsing issues with function scope, generics, and test packages

### DIFF
--- a/cmd/goimportcycle/main.go
+++ b/cmd/goimportcycle/main.go
@@ -79,6 +79,10 @@ func parseFiles(
 				}
 
 				for _, pkg := range pkgs {
+					// Skip external test packages (they can't be imported, so won't cause cycles)
+					if strings.HasSuffix(pkg.Name, "_test") {
+						continue
+					}
 					ast.Walk(depVis, pkg)
 				}
 


### PR DESCRIPTION
This PR fixes several parsing issues that were causing errors when analyzing large codebases:

## Issues Fixed

### 1. Function-scoped declarations
**Problem:** Function-local variables were being tracked as file-level declarations, causing "duplicate declaration" errors when the same variable name was used in multiple functions.

**Solution:** Modified the visitor to return `nil` after emitting `FuncDecl` nodes, preventing descent into function bodies. Import cycle detection only needs package-level declarations.

### 2. File emission order
**Problem:** All files were emitted when processing a `Package` node, but `ImportSpec` nodes were processed later during the AST walk. This caused all imports to be assigned to the last file in the package, leading to "duplicate import" errors.

**Solution:** Added package context tracking (`currentPackage`, `currentDirName`) to the visitor. File nodes are now emitted individually as they're encountered, with proper filename lookup from the package context.

### 3. Blank identifier
**Problem:** The blank identifier `_` was being tracked like a regular declaration, but it's used for compile-time checks and can appear multiple times.

**Solution:** Skip tracking declarations named `_` in the `addGenDecl` function.

### 4. External test packages
**Problem:** Packages ending in `_test` (external test packages) were being processed, but they can coexist with regular packages in the same directory and cannot be imported.

**Solution:** Added filtering in `main.go` to skip packages with names ending in `_test`.

### 5. Generic type receivers
**Problem:** Methods on generic types like `*Foo[T]` or `Foo[T, U]` were causing errors because the receiver name extraction didn't handle generic type syntax.

**Solution:** Added `extractTypeName` function that recursively extracts base type names from `ast.IndexExpr` and `ast.IndexListExpr` nodes. Updated receiver type handling to support generic types.

### 6. Error messages
**Enhancement:** Added file paths to all error messages for easier debugging.

## Testing
These fixes were tested on a large codebase with:
- Generic types with single and multiple type parameters
- Extensive test coverage with external test packages
- Multiple functions using the same local variable names
- Compile-time interface checks using blank identifiers

The tool now successfully generates import cycle graphs for such codebases.